### PR TITLE
Abstractions for enforcing maximum or minimum length of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ apitest.New().
 	End()
 ```
 
+### LessThan
+
+Use `LessThan` to enforce a maximum length on the returned value.
+
+```go
+apitest.New().
+	Handler(handler).
+	Get("/articles?category=golang").
+	Expect(t).
+	Assert(jsonpath.LessThan(`$.items`, 4).
+	End()
+```
+
 ### Present / NotPresent
 
 Use `Present` and `NotPresent` to check the presence of a field in the response without evaluating its value

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ apitest.New().
 	End()
 ```
 
-given the response is `{"a": "hello", "b": 12345}` 
+given the response is `{"a": "hello", "b": 12345}`
 
 ### Contains
 
@@ -63,16 +63,16 @@ apitest.New().
 	End()
 ```
 
-### MoreThan
+### GreaterThan
 
-Use `MoreThan` to enforce a minimum length on the returned value.
+Use `GreaterThan` to enforce a minimum length on the returned value.
 
 ```go
 apitest.New().
 	Handler(handler).
 	Get("/articles?category=golang").
 	Expect(t).
-	Assert(jsonpath.MoreThan(`$.items`, 2).
+	Assert(jsonpath.GreaterThan(`$.items`, 2).
 	End()
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ apitest.New().
 	End()
 ```
 
+### MoreThan
+
+Use `MoreThan` to enforce a minimum length on the returned value.
+
+```go
+apitest.New().
+	Handler(handler).
+	Get("/articles?category=golang").
+	Expect(t).
+	Assert(jsonpath.MoreThan(`$.items`, 2).
+	End()
+```
+
 ### Present / NotPresent
 
 Use `Present` and `NotPresent` to check the presence of a field in the response without evaluating its value

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -80,6 +80,21 @@ func MoreThan(expression string, minimumLength int) apitest.Assert {
 	}
 }
 
+func LessThan(expression string, maximumLength int) apitest.Assert {
+	return func(res *http.Response, req *http.Request) error {
+		value, err := jsonPath(res.Body, expression)
+		if err != nil {
+			return err
+		}
+
+		v := reflect.ValueOf(value)
+		if v.Len() > maximumLength {
+			return errors.New(fmt.Sprintf("\"%d\" is less than \"%d\"", v.Len(), maximumLength))
+		}
+		return nil
+	}
+}
+
 func Present(expression string) apitest.Assert {
 	return func(res *http.Response, req *http.Request) error {
 		value, _ := jsonPath(res.Body, expression)

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -65,7 +65,7 @@ func Len(expression string, expectedLength int) apitest.Assert {
 	}
 }
 
-func MoreThan(expression string, minimumLength int) apitest.Assert {
+func GreaterThan(expression string, minimumLength int) apitest.Assert {
 	return func(res *http.Response, req *http.Request) error {
 		value, err := jsonPath(res.Body, expression)
 		if err != nil {

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -65,6 +65,21 @@ func Len(expression string, expectedLength int) apitest.Assert {
 	}
 }
 
+func MoreThan(expression string, minimumLength int) apitest.Assert {
+	return func(res *http.Response, req *http.Request) error {
+		value, err := jsonPath(res.Body, expression)
+		if err != nil {
+			return err
+		}
+
+		v := reflect.ValueOf(value)
+		if v.Len() < minimumLength {
+			return errors.New(fmt.Sprintf("\"%d\" is greater than \"%d\"", v.Len(), minimumLength))
+		}
+		return nil
+	}
+}
+
 func Present(expression string) apitest.Assert {
 	return func(res *http.Response, req *http.Request) error {
 		value, _ := jsonPath(res.Body, expression)

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -157,7 +157,7 @@ func TestApiTest_Len(t *testing.T) {
 		End()
 }
 
-func TestApiTest_MoreThan(t *testing.T) {
+func TestApiTest_GreaterThan(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -172,8 +172,8 @@ func TestApiTest_MoreThan(t *testing.T) {
 		Handler(handler).
 		Get("/hello").
 		Expect(t).
-		Assert(MoreThan(`$.a`, 2)).
-		Assert(MoreThan(`$.b`, 0)).
+		Assert(GreaterThan(`$.a`, 2)).
+		Assert(GreaterThan(`$.b`, 0)).
 		End()
 }
 

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -3,12 +3,12 @@ package jsonpath
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
 	"github.com/steinfletcher/apitest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApiTest_Contains(t *testing.T) {
@@ -154,6 +154,26 @@ func TestApiTest_Len(t *testing.T) {
 		Expect(t).
 		Assert(Len(`$.a`, 3)).
 		Assert(Len(`$.b`, 1)).
+		End()
+}
+
+func TestApiTest_MoreThan(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c"}`))
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	apitest.New().
+		Handler(handler).
+		Get("/hello").
+		Expect(t).
+		Assert(MoreThan(`$.a`, 2)).
+		Assert(MoreThan(`$.b`, 0)).
 		End()
 }
 

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -177,6 +177,26 @@ func TestApiTest_MoreThan(t *testing.T) {
 		End()
 }
 
+func TestApiTest_LessThan(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c"}`))
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	apitest.New().
+		Handler(handler).
+		Get("/hello").
+		Expect(t).
+		Assert(LessThan(`$.a`, 4)).
+		Assert(LessThan(`$.b`, 2)).
+		End()
+}
+
 func TestApiTest_Present(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
In one of my projects, I came across the need for not only asserting a specific length but also asserting a minimum and maximum length. Working against a database that mirrors a live one, records unrelated to the tests may appear and disappear, making the total size of the response payload indeterministic.

I thought that this is something others may appreciate so here I am 🎊 

Each function and related test/docs can be found in a separate commit.