### PR TITLE
Flipped order of arguments in error message

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -29,7 +29,7 @@ func Contains(expression string, expected interface{}) apitest.Assert {
 			return errors.New(fmt.Sprintf("\"%s\" could not be applied builtin len()", expected))
 		}
 		if !found {
-			return errors.New(fmt.Sprintf("\"%s\" does not contain \"%s\"", expected, value))
+			return errors.New(fmt.Sprintf("\"%s\" does not contain \"%s\"", value, expected))
 		}
 		return nil
 	}


### PR DESCRIPTION
After some debugging today, I noticed that one of the error messages used in `jsonpath.Contains` had its arguments flipped.  For example, given `[1, 2, 3]`
```go
jsonpath.Contains("$[:]", float64(4))
```
... yields an error message `"4" does not contain "[1, 2, 3]"`.
I think the arguments for the print should be reversed.