### PR TITLE
Ensure assertions using Len() do not panic on nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2022 Stein Fletcher
+Copyright (c) 2023 Stein Fletcher
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/http/http.go
+++ b/http/http.go
@@ -70,4 +70,3 @@ func CopyRequest(request *http.Request) *http.Request {
 
 	return resCopy
 }
-

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -1,13 +1,13 @@
 package jsonpath
 
 import (
-	"errors"
 	"fmt"
-	httputil "github.com/steinfletcher/apitest-jsonpath/http"
-	"github.com/steinfletcher/apitest-jsonpath/jsonpath"
 	"net/http"
 	"reflect"
 	regex "regexp"
+
+	httputil "github.com/steinfletcher/apitest-jsonpath/http"
+	"github.com/steinfletcher/apitest-jsonpath/jsonpath"
 )
 
 // Contains is a convenience function to assert that a jsonpath expression extracts a value in an array
@@ -71,11 +71,11 @@ func Matches(expression string, regexp string) func(*http.Response, *http.Reques
 	return func(res *http.Response, req *http.Request) error {
 		pattern, err := regex.Compile(regexp)
 		if err != nil {
-			return errors.New(fmt.Sprintf("invalid pattern: '%s'", regexp))
+			return fmt.Errorf("invalid pattern: '%s'", regexp)
 		}
 		value, _ := jsonpath.JsonPath(res.Body, expression)
 		if value == nil {
-			return errors.New(fmt.Sprintf("no match for pattern: '%s'", expression))
+			return fmt.Errorf("no match for pattern: '%s'", expression)
 		}
 		kind := reflect.ValueOf(value).Kind()
 		switch kind {
@@ -95,11 +95,11 @@ func Matches(expression string, regexp string) func(*http.Response, *http.Reques
 			reflect.Float64,
 			reflect.String:
 			if !pattern.Match([]byte(fmt.Sprintf("%v", value))) {
-				return errors.New(fmt.Sprintf("value '%v' does not match pattern '%v'", value, regexp))
+				return fmt.Errorf("value '%v' does not match pattern '%v'", value, regexp)
 			}
 			return nil
 		default:
-			return errors.New(fmt.Sprintf("unable to match using type: %s", kind.String()))
+			return fmt.Errorf("unable to match using type: %s", kind.String())
 		}
 	}
 }

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
 	"io"
 	"io/ioutil"
 	"reflect"
 	"strings"
+
+	"github.com/PaesslerAG/jsonpath"
 )
 
 func Contains(expression string, expected interface{}, data io.Reader) error {
@@ -19,10 +20,10 @@ func Contains(expression string, expected interface{}, data io.Reader) error {
 	}
 	ok, found := IncludesElement(value, expected)
 	if !ok {
-		return errors.New(fmt.Sprintf("\"%s\" could not be applied builtin len()", expected))
+		return fmt.Errorf("\"%s\" could not be applied builtin len()", expected)
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("\"%s\" does not contain \"%s\"", value, expected))
+		return fmt.Errorf("\"%s\" does not contain \"%s\"", value, expected)
 	}
 	return nil
 }
@@ -33,7 +34,7 @@ func Equal(expression string, expected interface{}, data io.Reader) error {
 		return err
 	}
 	if !ObjectsAreEqual(value, expected) {
-		return errors.New(fmt.Sprintf("\"%s\" not equal to \"%s\"", value, expected))
+		return fmt.Errorf("\"%s\" not equal to \"%s\"", value, expected)
 	}
 	return nil
 }
@@ -45,7 +46,7 @@ func NotEqual(expression string, expected interface{}, data io.Reader) error {
 	}
 
 	if ObjectsAreEqual(value, expected) {
-		return errors.New(fmt.Sprintf("\"%s\" value is equal to \"%s\"", expression, expected))
+		return fmt.Errorf("\"%s\" value is equal to \"%s\"", expression, expected)
 	}
 	return nil
 }
@@ -56,9 +57,13 @@ func Length(expression string, expectedLength int, data io.Reader) error {
 		return err
 	}
 
+	if value == nil {
+		return errors.New("value is null")
+	}
+
 	v := reflect.ValueOf(value)
 	if v.Len() != expectedLength {
-		return errors.New(fmt.Sprintf("\"%d\" not equal to \"%d\"", v.Len(), expectedLength))
+		return fmt.Errorf("\"%d\" not equal to \"%d\"", v.Len(), expectedLength)
 	}
 	return nil
 }
@@ -69,9 +74,13 @@ func GreaterThan(expression string, minimumLength int, data io.Reader) error {
 		return err
 	}
 
+	if value == nil {
+		return fmt.Errorf("value is null")
+	}
+
 	v := reflect.ValueOf(value)
 	if v.Len() < minimumLength {
-		return errors.New(fmt.Sprintf("\"%d\" is greater than \"%d\"", v.Len(), minimumLength))
+		return fmt.Errorf("\"%d\" is greater than \"%d\"", v.Len(), minimumLength)
 	}
 	return nil
 }
@@ -82,9 +91,13 @@ func LessThan(expression string, maximumLength int, data io.Reader) error {
 		return err
 	}
 
+	if value == nil {
+		return fmt.Errorf("value is null")
+	}
+
 	v := reflect.ValueOf(value)
 	if v.Len() > maximumLength {
-		return errors.New(fmt.Sprintf("\"%d\" is less than \"%d\"", v.Len(), maximumLength))
+		return fmt.Errorf("\"%d\" is less than \"%d\"", v.Len(), maximumLength)
 	}
 	return nil
 }
@@ -92,7 +105,7 @@ func LessThan(expression string, maximumLength int, data io.Reader) error {
 func Present(expression string, data io.Reader) error {
 	value, _ := JsonPath(data, expression)
 	if isEmpty(value) {
-		return errors.New(fmt.Sprintf("value not present for expression: '%s'", expression))
+		return fmt.Errorf("value not present for expression: '%s'", expression)
 	}
 	return nil
 }
@@ -100,7 +113,7 @@ func Present(expression string, data io.Reader) error {
 func NotPresent(expression string, data io.Reader) error {
 	value, _ := JsonPath(data, expression)
 	if !isEmpty(value) {
-		return errors.New(fmt.Sprintf("value present for expression: '%s'", expression))
+		return fmt.Errorf("value present for expression: '%s'", expression)
 	}
 	return nil
 }

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -2,6 +2,7 @@ package jsonpath_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -18,7 +19,7 @@ func TestApiTest_Contains(t *testing.T) {
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"a": 12345, "b": [{"key": "c", "value": "result"}]}`))
+		_, err := w.Write([]byte(`{"a": 12345, "b": [{"key": "c", "value": "result"}], "d": null}`))
 		if err != nil {
 			panic(err)
 		}
@@ -151,7 +152,7 @@ func TestApiTest_Len(t *testing.T) {
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c"}`))
+		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c", "d": null}`))
 		if err != nil {
 			panic(err)
 		}
@@ -163,6 +164,17 @@ func TestApiTest_Len(t *testing.T) {
 		Expect(t).
 		Assert(jsonpath.Len(`$.a`, 3)).
 		Assert(jsonpath.Len(`$.b`, 1)).
+		Assert(func(r1 *http.Response, r2 *http.Request) error {
+			err := jsonpath.Len(`$.d`, 0)(r1, r2)
+
+			if err == nil {
+				return errors.New("jsonpath.Len was expected to fail on null value but it didn't")
+			}
+
+			assert.EqualError(t, err, "value is null")
+
+			return nil
+		}).
 		End()
 }
 
@@ -171,7 +183,7 @@ func TestApiTest_GreaterThan(t *testing.T) {
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c"}`))
+		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c", "d": null}`))
 		if err != nil {
 			panic(err)
 		}
@@ -183,6 +195,17 @@ func TestApiTest_GreaterThan(t *testing.T) {
 		Expect(t).
 		Assert(jsonpath.GreaterThan(`$.a`, 2)).
 		Assert(jsonpath.GreaterThan(`$.b`, 0)).
+		Assert(func(r1 *http.Response, r2 *http.Request) error {
+			err := jsonpath.GreaterThan(`$.d`, 5)(r1, r2)
+
+			if err == nil {
+				return errors.New("jsonpath.GreaterThan was expected to fail on null value but it didn't")
+			}
+
+			assert.EqualError(t, err, "value is null")
+
+			return nil
+		}).
 		End()
 }
 
@@ -191,7 +214,7 @@ func TestApiTest_LessThan(t *testing.T) {
 	handler.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c"}`))
+		_, err := w.Write([]byte(`{"a": [1, 2, 3], "b": "c", "d": null}`))
 		if err != nil {
 			panic(err)
 		}
@@ -203,6 +226,17 @@ func TestApiTest_LessThan(t *testing.T) {
 		Expect(t).
 		Assert(jsonpath.LessThan(`$.a`, 4)).
 		Assert(jsonpath.LessThan(`$.b`, 2)).
+		Assert(func(r1 *http.Response, r2 *http.Request) error {
+			err := jsonpath.LessThan(`$.d`, 5)(r1, r2)
+
+			if err == nil {
+				return errors.New("jsonpath.LessThan was expected to fail on null value but it didn't")
+			}
+
+			assert.EqualError(t, err, "value is null")
+
+			return nil
+		}).
 		End()
 }
 
@@ -263,15 +297,15 @@ func TestApiTest_Chain(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`{
-		  "a": {
+			"a": {
 			"b": {
-			  "c": {
+				"c": {
 				"d": 1,
 				"e": "2",
 				"f": [3, 4, 5]
-			  }
+				}
 			}
-		  }
+			}
 		}`))
 		if err != nil {
 			panic(err)

--- a/jwt.go
+++ b/jwt.go
@@ -5,9 +5,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/steinfletcher/apitest-jsonpath/jsonpath"
 	"net/http"
 	"strings"
+
+	"github.com/steinfletcher/apitest-jsonpath/jsonpath"
 )
 
 const (
@@ -32,13 +33,13 @@ func jwtEqual(tokenSelector func(*http.Response) (string, error), expression str
 
 		parts := strings.Split(token, ".")
 		if len(parts) != 3 {
-			splitErr := errors.New("Invalid token: token should contain header, payload and secret")
+			splitErr := errors.New("invalid token: token should contain header, payload and secret")
 			return splitErr
 		}
 
 		decodedPayload, PayloadErr := base64Decode(parts[index])
 		if PayloadErr != nil {
-			return fmt.Errorf("Invalid jwt: %s", PayloadErr.Error())
+			return fmt.Errorf("invalid jwt: %s", PayloadErr.Error())
 		}
 
 		value, err := jsonpath.JsonPath(bytes.NewReader(decodedPayload), expression)
@@ -61,7 +62,7 @@ func base64Decode(src string) ([]byte, error) {
 
 	decoded, err := base64.URLEncoding.DecodeString(src)
 	if err != nil {
-		errMsg := fmt.Errorf("Decoding Error %s", err)
+		errMsg := fmt.Errorf("decoding Error %s", err)
 		return nil, errMsg
 	}
 	return decoded, nil

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,10 +1,11 @@
 package mocks
 
 import (
+	"net/http"
+
 	"github.com/steinfletcher/apitest"
 	httputil "github.com/steinfletcher/apitest-jsonpath/http"
 	"github.com/steinfletcher/apitest-jsonpath/jsonpath"
-	"net/http"
 )
 
 // Contains is a convenience function to assert that a jsonpath expression extracts a value in an array

--- a/mocks/mocks_test.go
+++ b/mocks/mocks_test.go
@@ -3,11 +3,12 @@ package mocks_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/steinfletcher/apitest-jsonpath/mocks"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/steinfletcher/apitest-jsonpath/mocks"
 
 	"github.com/steinfletcher/apitest"
 )


### PR DESCRIPTION
Ensure assertions using Len() do not panic on nil in order to keep sequence diagrams reports

Example of previous error:

```go
apitest.New().
	Report(apitest.SequenceDiagram()). // Report as a sequence diagram
	Handler(server).
	Get("/api/v1/some/endpoint").
	Header(authH, token).
	Expect(t).
	Status(http.StatusOK).
	Assert(jsonpath.Present(`$.data`)). // Checks it's not null (works fine)
	Assert(jsonpath.GreaterThan(`$.data`, 0)). // Breaks if null without the sequence diagram (should not panic!)
	End()
```

The GreaterThan test is failing with panic() and the sequence diagram is not generated (which is annoying, because I would like to see why the test is failing, and check what the server returned in the response body)

```text/plain
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 5m -run ^Test_My_Api_Returns_Data_Array$ my.repo/my.package/test

--- FAIL: Test_My_Api_Returns_Data_Array (0.23s)
    c:\repos\my-repo\my-test\assert.go:105: 
        	Error Trace:	assert.go:259
        	            				assert.go:89
        	            				assert.go:113
        	            				apitest.go:909
        	            				apitest.go:891
        	            				apitest.go:779
        	            				apitest.go:693
        	            				machine_data_controller_test.go:498
        	Error:      	Received unexpected error:
        	            	value not present for expression: '$.data'
        	Test:       	Test_My_Api_Returns_Data_Array
    c:\repos\my-repo\my-test\assert.go:105: 
        	Error Trace:	assert.go:259
        	            				assert.go:89
        	            				assert.go:113
        	            				apitest.go:909
        	            				apitest.go:891
        	            				apitest.go:779
        	            				apitest.go:693
        	            				machine_data_controller_test.go:498
        	Error:      	Received unexpected error:
        	            	"$.data" value is equal to "%!s(<nil>)"
        	Test:       	Test_My_Api_Returns_Data_Array
panic: reflect: call of reflect.Value.Len on zero Value [recovered]
	panic: reflect: call of reflect.Value.Len on zero Value

goroutine 74 [running]:
testing.tRunner.func1.2({0x17db420, 0xc00011c8b8})
	C:/Program Files/Go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
	C:/Program Files/Go/src/testing/testing.go:1529 +0x39f
panic({0x17db420, 0xc00011c8b8})
	C:/Program Files/Go/src/runtime/panic.go:884 +0x213
reflect.Value.lenNonSlice({0x0?, 0x0?, 0x18de361?})
	C:/Program Files/Go/src/reflect/value.go:1714 +0x165
reflect.Value.Len(...)
	C:/Program Files/Go/src/reflect/value.go:1693
github.com/steinfletcher/apitest-jsonpath/jsonpath.GreaterThan({0x18de361?, 0xc0003a0f20?}, 0x0, {0x219fe91b658?, 0xc0004952c0?})
	C:/Users/user.name/go/pkg/mod/github.com/steinfletcher/apitest-jsonpath@v1.7.1/jsonpath/jsonpath.go:73 +0x10c
github.com/steinfletcher/apitest-jsonpath.GreaterThan.func1(0xc00050c500?, 0x1a7c3b0?)
	C:/Users/user.name/go/pkg/mod/github.com/steinfletcher/apitest-jsonpath@v1.7.1/jsonpath.go:44 +0x65
github.com/steinfletcher/apitest.(*APITest).assertFunc(0xc0006405a0, 0xc00059ebd0?, 0x155?)
	C:/Users/user.name/go/pkg/mod/github.com/steinfletcher/apitest@v1.5.14/apitest.go:907 +0xdf
github.com/steinfletcher/apitest.(*Response).runTest(0x0?)
	C:/Users/user.name/go/pkg/mod/github.com/steinfletcher/apitest@v1.5.14/apitest.go:891 +0x3a8
github.com/steinfletcher/apitest.(*APITest).report(0xc0006405a0)
	C:/Users/user.name/go/pkg/mod/github.com/steinfletcher/apitest@v1.5.14/apitest.go:779 +0x371
github.com/steinfletcher/apitest.(*Response).End(0xc00038a300)
	C:/Users/user.name/go/pkg/mod/github.com/steinfletcher/apitest@v1.5.14/apitest.go:693 +0x137
my.repo/my.package/test.Test_My_Api_Returns_Data_Array(0xc000441ba0)
	C:/repos/my-repo/my-test/my_test.go:498 +0xbca
testing.tRunner(0xc000441ba0, 0x1962528)
	C:/Program Files/Go/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
	C:/Program Files/Go/src/testing/testing.go:1629 +0x3ea
FAIL	my.repo/my.package/my-test	1.611s
FAIL

```